### PR TITLE
refactor branch

### DIFF
--- a/handlers/catalog.py
+++ b/handlers/catalog.py
@@ -1,10 +1,45 @@
-from aiogram import Router, types
+from aiogram import Router, types, F
 from aiomysql import create_pool
 from config import config
 
 router = Router()
 
-@router.message(lambda msg: msg.text == "/catalog")
+
+async def fetch_categories(cur):
+    await cur.execute("SELECT id, name FROM categories")
+    return await cur.fetchall()
+
+
+async def fetch_products_by_category(cur, cat_id):
+    await cur.execute(
+        "SELECT name, description, price FROM products WHERE category_id = %s",
+        (cat_id,)
+    )
+    return await cur.fetchall()
+
+
+def format_product(name, desc, price):
+    desc = desc or "Без опису"
+    price = price or 0.00
+    return (
+        f"• <b>{name}</b>\n"
+        f"{desc}\n"
+        f"💵 {price:.2f} грн\n"
+        f"👉 /order_{name.replace(' ', '_')}\n\n"
+    )
+
+
+def format_category_block(cat_name, products):
+    response = f"<b>📂 {cat_name}</b>\n\n"
+    if products:
+        for name, desc, price in products:
+            response += format_product(name, desc, price)
+    else:
+        response += "Наразі немає товарів у цій категорії."
+    return response
+
+
+@router.message(F.text == "/catalog")
 async def show_catalog(message: types.Message):
     async with create_pool(
         host=config.db_config.host,
@@ -15,39 +50,20 @@ async def show_catalog(message: types.Message):
     ) as pool:
         async with pool.acquire() as conn:
             async with conn.cursor() as cur:
-                await cur.execute("SELECT id, name FROM categories")
-                categories = await cur.fetchall()
+                categories = await fetch_categories(cur)
 
                 if not categories:
                     return await message.answer("❗ Каталог порожній.")
 
                 for cat_id, cat_name in categories:
-                    response = f"<b>📂 {cat_name}</b>\n\n"
-
-                    await cur.execute(
-                        "SELECT name, description, price FROM products WHERE category_id = %s",
-                        (cat_id,)
-                    )
-                    products = await cur.fetchall()
-
-                    if products:
-                        for name, desc, price in products:
-                            desc = desc or "Без опису"
-                            price = price or 0.00
-                            response += (
-                                f"• <b>{name}</b>\n"
-                                f"{desc}\n"
-                                f"💵 {price} грн\n"
-                                f"👉 /order_{name.replace(' ', '_')}\n\n"
-                            )
-                    else:
-                        response += "Наразі немає товарів у цій категорії."
-
+                    products = await fetch_products_by_category(cur, cat_id)
+                    response = format_category_block(cat_name, products)
                     await message.answer(response, parse_mode="HTML")
 
-@router.message(lambda m: m.text.startswith("/order_"))
+
+@router.message(F.text.startswith("/order_"))
 async def handle_order(message: types.Message):
-    product_name = message.text.replace("/order_", "").replace("_", " ")
+    product_name = message.text.removeprefix("/order_").replace("_", " ")
     await message.answer(
         f"📦 Ви обрали товар: <b>{product_name}</b>\n"
         f"Наш менеджер незабаром зв'яжеться з вами!",


### PR DESCRIPTION
🧠 Problem
The original /catalog command handler had several code smells:

Repeated SQL query logic and response formatting were scattered throughout the function

Long, nested async blocks reduced readability

Lambda-based filters in route registration made the code less declarative

Difficult to extend or test due to monolithic structure

✅ Changes Made
Extracted SQL operations into helper functions:

fetch_categories()

fetch_products_by_category()

Moved message formatting into reusable functions:

format_product()

format_category_block()

Replaced lambda filters with F.text for better clarity and IDE support

Used .removeprefix() instead of manual string replacement

📈 Benefits
Improves readability and separation of concerns

Makes the code easier to maintain and expand

Reduces duplicated logic

Keeps the handlers focused on one responsibility: responding to a message

🧾 Files Changed
handlers/catalog.py (or wherever this router code lives)

📈 Що покращено
✔️ Код DRY (Don't Repeat Yourself)
✔️ Краще читається, зручніше підтримувати та тестувати